### PR TITLE
Move to pronouns.org

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ description: |
   Pete Johns (/piːt ʤɒnz/ - he/him/his): Human being; just like you.
 description_html: |
   Pete Johns (<a href="https://nmdrp.me/petejohns"><em>/piːt ʤɒnz/</em></a> -
-  <a href="https://pronoun.is/he">he/him/his</a>): Human being; just like you.
+  <a href="https://pronouns.org/he">he/him/his</a>): Human being; just like you.
 permalink: /blog/:year/:month/:day/:title/
 paginate: 10
 paginate_path: "blog/page:num/"


### PR DESCRIPTION
Context
-----
An email from @rutson alerted me that pronoun.is is missing, presumed... missing. https://github.com/witch-house/pronoun.is/issues/147

Change
------

Move to pronouns.org

Considerations
-------

There are a number of alternatives but I went with this one because of the simple URI.